### PR TITLE
Fixes AB#631170

### DIFF
--- a/common_module_human_health_hazard_assessment.ftl
+++ b/common_module_human_health_hazard_assessment.ftl
@@ -1183,8 +1183,9 @@
 						<td>
 							<#if com.picklistValueMatchesPhrases(study.AdministrativeData.Endpoint, ["eye irritation: in vitro / ex vivo"])>
 							<para>in vitro study</para>
-							<@nonHumanStudyMethod study/>
 							</#if>
+
+							<@nonHumanStudyMethod study/>
 						</td>
 						<!-- Results -->
 						<td>
@@ -2019,8 +2020,9 @@
 						<td>
 						<#if com.picklistValueMatchesPhrases(study.AdministrativeData.Endpoint, ["respiratory sensitisation: in vitro", "respiratory sensitisation: in chemico"])>
 							<para>in vitro study</para>							
-						<@nonHumanStudyMethod study />
 						</#if>
+
+						<@nonHumanStudyMethod study />
 						</td>
 						<!-- Results -->
 						<td>


### PR DESCRIPTION
Method was being omitted from the report when phrases weren't matched (see [screenshot](https://dev.azure.com/echa-ecm/8fd87d2f-4297-4bd5-b438-08eaa6ad1ff0/_apis/wit/attachments/f13a30e3-eabb-4ad6-8215-e3e4c86cb5e6?fileName=TBL_5.7.png&download=true&api-version=5.0-preview.2))
The apparent aim of the _if_ directive is to add an indicator whether the study was conducted in vitro.